### PR TITLE
added tear-down bootstrap script for octopus

### DIFF
--- a/bootstrap_octopus_tear-down.sh
+++ b/bootstrap_octopus_tear-down.sh
@@ -1,0 +1,15 @@
+# !/bin/bash
+export FFFS_WEB_PORTAL_STAGING_DB_ADMIN_USERNAME='#{webPortalStagingDbAdminUsername}'
+export FFFS_WEB_PORTAL_STAGING_DB_ADMIN_PASSWORD='#{webPortalStagingDbAdminPassword}'
+export FFFS_WEB_PORTAL_STAGING_DB_CONNECTION_STRING='#{webPortalStagingDbConnectionString}'
+export FFFS_WEB_PORTAL_STAGING_DB_STAGING_SCHEMA='#{webPortalStagingDbStagingSchema}'
+export FFFS_WEB_PORTAL_STAGING_DB_USERNAME='#{webPortalStagingDbUsername}'
+export FFFS_WEB_PORTAL_STAGING_DB_REPORTING_SCHEMA='#{webPortalStagingDbReportingSchema}'
+export FFFS_WEB_PORTAL_STAGING_DB_REPORTING_USERNAME='#{webPortalStagingDbReportingUsername}'
+export FFFS_WEB_PORTAL_STAGING_DB_REPORTING_PASSWORD='#{webPortalStagingDbReportingPassword}'
+
+
+# WARNING - This command will drop the schemas defined in pom.xml.
+# Do NOT use in the production environment.
+echo "Executing Maven DB script"
+mvn liquibase:dropAll


### PR DESCRIPTION
Added bootstrap_octopus_tear-down.sh to the solution.

This is for use by Octopus to run scripts against database by exporting the required environmental variables to authenticate to the database.