### PR TITLE
Fix/use datetime2 in import times view

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>uk.gov.defra.future-flood-forecasting-web-portal</groupId>
     <artifactId>future-flood-forecasting-web-portal-staging-database</artifactId>
     <packaging>jar</packaging>
-    <version>0.13.0</version>
+    <version>0.13.1</version>
     <name>future-flood-forecasting-web-portal-staging-database</name>
     <url>https://github.com/DEFRA/future-flood-forecasting-web-portal</url>
 

--- a/src/main/resources/changelogs/db.changelog-create-datetime2-based-task-import-times-view.xml
+++ b/src/main/resources/changelogs/db.changelog-create-datetime2-based-task-import-times-view.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<databaseChangeLog 
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd"> 
+  <changeSet author="pwadmore" id="changelog-create-datetime2-based-task-import-times-view">
+    <sql>
+      <![CDATA[
+        CREATE OR ALTER VIEW FFF_REPORTING.TASK_IMPORT_TIMES AS
+        SELECT
+          TH.TASK_RUN_ID,
+          TH.WORKFLOW_ID,
+          T.ID AS TS_ID,
+          LEN(T.FEWS_DATA) AS SIZE,
+          CONVERT(DATETIME2 ,TH.TASK_COMPLETION_TIME,1) AS TASK_COMPLETION_TIME,
+          DATEDIFF(s, TH.TASK_COMPLETION_TIME, TH.IMPORT_TIME) AS STAGING_TIME,
+          CONVERT(DATETIME2 ,TH.IMPORT_TIME,1) AS IMPORT_TIME,
+          DATEDIFF(s, TH.IMPORT_TIME, TJ.JOB_STATUS_TIME) AS FME_QUEUE_TIME,
+          CONVERT(DATETIME2 ,TJ.JOB_STATUS_TIME,1) AS FME_START_TIME,
+          TJ.ID AS JOB_ID,
+          DATEDIFF(s, TJ.JOB_STATUS_TIME, TJ2.JOB_STATUS_TIME) AS FME_PROCESS_TIME,
+          CONVERT(DATETIME2 ,TJ2.JOB_STATUS_TIME,1) AS FME_END_TIME,
+          TJ2.JOB_STATUS,
+          TJ2.DESCRIPTION
+        FROM
+          FFF_STAGING.TIMESERIES AS T INNER JOIN
+          FFF_STAGING.TIMESERIES_HEADER AS TH ON T.TIMESERIES_HEADER_ID = TH.ID INNER JOIN
+          FFF_REPORTING.TIMESERIES_JOB AS TJ ON T.ID = TJ.TIMESERIES_ID INNER JOIN
+          FFF_REPORTING.TIMESERIES_JOB AS TJ2 ON TJ.TIMESERIES_ID = TJ2.TIMESERIES_ID
+        WHERE
+          TJ.JOB_STATUS = 1 AND TJ2.JOB_STATUS <> 1
+      ]]>
+    </sql>
+    <rollback>
+      <sql>
+        <![CDATA[
+          CREATE OR ALTER VIEW FFF_REPORTING.TASK_IMPORT_TIMES AS
+          SELECT
+            TH.TASK_RUN_ID,
+            TH.WORKFLOW_ID,
+            T.ID AS TS_ID,
+            LEN(T.FEWS_DATA) AS SIZE,
+            TH.TASK_COMPLETION_TIME,
+            DATEDIFF(s, TH.TASK_COMPLETION_TIME, TH.IMPORT_TIME) AS STAGING_TIME,
+            TH.IMPORT_TIME,
+            DATEDIFF(s, TH.IMPORT_TIME, TJ.JOB_STATUS_TIME) AS FME_QUEUE_TIME,
+            TJ.JOB_STATUS_TIME AS FME_START_TIME,
+            TJ.ID AS JOB_ID,
+            DATEDIFF(s, TJ.JOB_STATUS_TIME, TJ2.JOB_STATUS_TIME) AS FME_PROCESS_TIME,
+            TJ2.JOB_STATUS_TIME AS FME_END_TIME,
+            TJ2.JOB_STATUS,
+            TJ2.DESCRIPTION
+          FROM
+            FFF_STAGING.TIMESERIES AS T INNER JOIN
+            FFF_STAGING.TIMESERIES_HEADER AS TH ON T.TIMESERIES_HEADER_ID = TH.ID INNER JOIN
+            FFF_REPORTING.TIMESERIES_JOB AS TJ ON T.ID = TJ.TIMESERIES_ID INNER JOIN
+            FFF_REPORTING.TIMESERIES_JOB AS TJ2 ON TJ.TIMESERIES_ID = TJ2.TIMESERIES_ID
+          WHERE
+            TJ.JOB_STATUS = 1 AND TJ2.JOB_STATUS <> 1
+        ]]>
+      </sql>
+    </rollback>
+  </changeSet>
+</databaseChangeLog> 

--- a/src/main/resources/changelogs/db.changelog-master.xml
+++ b/src/main/resources/changelogs/db.changelog-master.xml
@@ -116,4 +116,5 @@
   <include file="./changelogs/db.changelog-grant-execute-on-delete-timseries-audit-stored-procedure-to-reporting-reader-writer-role.xml"/>
   <include file="./changelogs/db.changelog-grant-execute-on-delete-timseries-object-stored-procedure-to-reporting-reader-writer-role.xml"/>
   <include file="./changelogs/db.changelog-add-ignored-workflows-to-workflow-view.xml"/>
+  <include file="./changelogs/db.changelog-create-datetime2-based-task-import-times-view.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/IWP-683

DATETIME2 is required by the portal dashboard